### PR TITLE
Fix no data being loaded on devices with a language not set to `EN`

### DIFF
--- a/F1TV/API.swift
+++ b/F1TV/API.swift
@@ -88,6 +88,7 @@ class F1TV {
         "apikey": apiKey,
         "cd-systemid": systemId,
         "User-Agent": "RaceControl",
+        "accept-language": "en",
     ]
 
     // MARK: - Login


### PR DESCRIPTION
## Problem
When running the app on a device where the language was not set to `English` (EN) the view just stayed empty as there was no data loaded. The reason for this was that the `accept-language` HTTP-header was automatically set to the device's language. When this value does not include `EN` the response will not contain any data. It just returned `{ "objects": [] }`.

## Fix
Hardcode the `accept-language` HTTP-header to `EN`. 